### PR TITLE
Remove parent directory during octo-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Defines the `Id` component of the created package. By default it will extract th
 #### version (optional)
 Defines the `version` component of the created package. By default it will extract the version out of `package.json` if present.
 
+#### removeParent (optional)
+If set to `true` the parent directory will be removed. The `parentDir` paramenter also needs to be set.
+
+#### parentDir (optional)
+Defines the parent directory to be removed if `removeParent` set to true.
+
 #### dst
 The output location for the generated package file.
 
@@ -57,7 +63,9 @@ grunt.initConfig({
     "octo-pack": {
       prod: {
         options: {
-          dst: './bin'
+          dst: './bin',
+          removeParent: true,
+          parentDir: 'dist'
         },
         src: ['**/*', '!src/**/*', '!./gulpfile.js']
       }

--- a/tasks/pack.js
+++ b/tasks/pack.js
@@ -10,16 +10,25 @@ module.exports = function(grunt) {
         var done = this.async(),
             files = grunt.file.expand(this.filesSrc),
             options = this.options({
-                dst: './'
+                dst: './',
+                removeParent: false,
+                parentDir: ''
             });
-        if(files.length === 0) {
+      if(files.length === 0) {
             grunt.log.warn('No packages found.');
             done();
         } else {
             try {
                 var pkg = octo.pack(options.type, {id: options.id, version: options.version});
                 files.forEach(function(f) {
-                    pkg.append(f);
+                    var p = f;
+                    if(options.removeParent && options.parentDir) {
+                        if (p.startsWith(options.parentDir + '/')) {
+                            p = p.replace(options.parentDir + '/', "");
+                            grunt.log.writeln('Filepath renamed to: ' + p);
+                        }
+                    }
+                    pkg.append(p, f);
                 });
                 pkg.toFile(options.dst, function (err, data) {
                     if(err) {


### PR DESCRIPTION
Adds 2 options to allow the parent folder to be removed when octo-pack is run.

This can be used when pulling the source from a `dist` folder, but need to deploy the containing files and not the containing folder.