### PR TITLE
Fixing up the use of the cwd variable in the grunt task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tmp/
 
 # OS generated files
 .idea
+*.iml
 .DS_Store
 Thumbs.db
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@octopusdeploy/grunt-octo",
   "description": "A Grunt wrapper for octopack library to push projects to Octopus Deploy.",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "author": "Octopus Deploy <support@octopus.com> (http://octopus.com/)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR allows the `cwd` option to be used when packing up an archive e.g.

```
prodNoFolderZip: {
                options: {
                    dst: './bin',
                    type: 'zip'
                },
                src: ['**/*.txt'],
                cwd: 'dist'
            }
```

See https://github.com/mcasperson/GruntOctoExample for examples of how the `cwd` option can be used.